### PR TITLE
make from_str() consistent for United States

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,8 @@
 //! - `from_code` - create `Country` from three digit code
 //! - `from_alpha2` - create `Country` from two letter code
 //! - `from_alpha3` - create `Country` from three letter code
-//! - `from_alias` - create `Country` from a common alias. This only works for some countries as not all countries have aliases
+//! - `from_alias` - create `Country` from a common alias stripped of any spaces or
+//!   underscores. This only works for some countries as not all countries have aliases
 //! - `from_name` - create `Country` from the full state name no space or underscores
 //!
 //! `Country` implements the [core::str::FromStr](https://doc.rust-lang.org/core/str/trait.FromStr.html) trait that accepts any valid argument to the previously mentioned functions
@@ -54,19 +55,22 @@
 //!
 //! ## From String Example
 //!
-//! ```
+//! ```rust
 //! use celes::Country;
 //! use core::str::FromStr;
 //!
-//! // All three of these are equivalent
-//! let usa_1 = Country::from_str("USA").unwrap();
-//! let usa_2 = Country::from_str("US").unwrap();
-//! let usa_3 = Country::from_str("America").unwrap();
+//! // All of these are equivalent
+//! assert_eq!("US", Country::from_str("USA").unwrap().alpha2);
+//! assert_eq!("US", Country::from_str("US").unwrap().alpha2);
+//! assert_eq!("US", Country::from_str("America").unwrap().alpha2);
+//! assert_eq!("US", Country::from_str("UnitedStates").unwrap().alpha2);
+//! assert_eq!("US", Country::from_str("TheUnitedStatesOfAmerica").unwrap().alpha2);
 //!
-//! // All three of these are equivalent
-//! let gb_1 = Country::from_str("England").unwrap();
-//! let gb_2 = Country::from_str("gb").unwrap();
-//! let gb_3 = Country::from_str("Scotland").unwrap();
+//! // All of these are equivalent
+//! assert_eq!("GB", Country::from_str("England").unwrap().alpha2);
+//! assert_eq!("GB", Country::from_str("gb").unwrap().alpha2);
+//! assert_eq!("GB", Country::from_str("Scotland").unwrap().alpha2);
+//! assert_eq!("GB", Country::from_str("TheUnitedKingdomOfGreatBritainAndNorthernIreland").unwrap().alpha2);
 //! ```
 /*
 * Copyright 2019 Michael Lodder
@@ -3313,6 +3317,7 @@ impl FromStr for Country {
             | "usa"
             | "america"
             | "united states"
+            | "unitedstates"
             | "unitedstatesofamerica" => Ok(Self::the_united_states_of_america()),
             "timorleste" | "timor_leste" | "626" | "tl" | "tls" => Ok(Self::timor_leste()),
             "togo" | "768" | "tg" | "tgo" => Ok(Self::togo()),


### PR DESCRIPTION
All of the `from_str()` alias match arms except for the United States
use the alias stripped of any spaces, so you can pass in your country
name like, for example:

```rust
let input = "Great Britain";
let country = Country::from_str(input.replace(" ", "").as_str()).unwrap();
```

However, the `"united states"` alias added in #1 breaks expectations
since it contains a space, while no other country aliases contain
spaces, and so requires doing something weird for the above example 
like:

```rust
let input = "United States";
let country_input = match input.to_lowercase().as_str() {
    "united states" => input,
    _ => input.replace(" ", "")
};
let country = Country::from_str(country_input.as_str()).unwrap();
```

This PR adds a new `"unitedstates"` alias to bring the US in line with
the rest of the countries in the `from_str` implementation. The
existing `"united states"` alias is not removed to avoid breaking
backwards compatibility.

I also updated the docs a little bit to make it more obvious that users
should strip spaces out of the input before passing to the various
methods, both by stating it explicitly and by including examples like
`"UnitedStates"` in the `from_str()` doctests, which have also been
slightly updated to perform assertions in addition to assigning values.