### PR TITLE
Reduce MSRV to 1.80

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ license = "Apache-2.0 OR MIT"
 name = "celes"
 readme = "README.md"
 repository = "https://github.com/mikelodder7/celes"
-version = "2.6.0"
+version = "2.6.1"
 rust-version = "1.80"
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ full state name, and short english aliases.
 """
 documentation = "https://docs.rs/celes/"
 categories = ["encoding", "parsing"]
-edition = "2024"
+edition = "2021"
 homepage = "https://crates.io/crates/celes"
 include = [
     "src/*.rs",
@@ -22,6 +22,7 @@ name = "celes"
 readme = "README.md"
 repository = "https://github.com/mikelodder7/celes"
 version = "2.6.0"
+rust-version = "1.80"
 
 [dependencies]
 serde = { version = "1", default-features = false, features = ["derive"] }


### PR DESCRIPTION
In https://github.com/mikelodder7/celes/commit/8479b1f45c5005bfd3c13452d5f401869d9699d5 you removed the rust-version metadata and bumped the edition to 2024 (seemingly without concrete rationale/benefits). For the sake of downstream libraries that prefer to be a little more conservative, please consider avoiding such MSRV bumps unless there is a substantial benefit (as in #15, for example).